### PR TITLE
Clear destination database option

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -3,3 +3,5 @@
 This is a C# console app that copies data between Microsoft SQL Server databases. Example use:
 
     AppHarbor.SqlServerBulkCopy.exe --srcserver=db000.appharbor.net --srcusername=dbxx --srcpassword=srcpassword --srcdatabasename=dbxx --dstserver=.\SQLEXPRESSADV --dstusername=dbyy --dstpassword=dstpassword --dstdatabasename=dbyy --ignoretables=TableToIgnore
+
+For trusted connections, just skip both the username and password parameters.

--- a/README.markdown
+++ b/README.markdown
@@ -2,6 +2,6 @@
 
 This is a C# console app that copies data between Microsoft SQL Server databases. Example use:
 
-    AppHarbor.SqlServerBulkCopy.exe --srcserver=db000.appharbor.net --srcusername=dbxx --srcpassword=srcpassword --srcdatabasename=dbxx --dstserver=.\SQLEXPRESSADV --dstusername=dbyy --dstpassword=dstpassword --dstdatabasename=dbyy --ignoretables=TableToIgnore
+    AppHarbor.SqlServerBulkCopy.exe --srcserver=db000.appharbor.net --srcusername=dbxx --srcpassword=srcpassword --srcdatabasename=dbxx --dstserver=.\SQLEXPRESSADV --dstusername=dbyy --dstpassword=dstpassword --dstdatabasename=dbyy --ignoretables=TableToIgnore --cleardstdatabase
 
 For trusted connections, just skip both the username and password parameters.

--- a/src/AppHarbor.SqlServerBulkCopy/Program.cs
+++ b/src/AppHarbor.SqlServerBulkCopy/Program.cs
@@ -41,11 +41,11 @@ namespace AppHarbor.SqlServerBulkCopy
 				{
 					throw new OptionException("source server not specified", "srcserver");
 				}
-				if (sourceUsername == null)
+				if (sourceUsername == null && sourcePassword != null)
 				{
 					throw new OptionException("source username not specified", "srcusername");
 				}
-				if (sourcePassword == null)
+				if (sourcePassword == null && sourceUsername != null)
 				{
 					throw new OptionException("source password not specified", "srcpassword");
 				}
@@ -86,7 +86,10 @@ namespace AppHarbor.SqlServerBulkCopy
 
 			Console.WriteLine("Retrieving source database table information...");
 
-			var sourceConnection = new ServerConnection(sourceServerName, sourceUsername, sourcePassword);
+			var usingTrustedConnection = string.IsNullOrEmpty(sourceUsername) && string.IsNullOrEmpty(sourcePassword);
+			var sourceConnection = usingTrustedConnection
+				? new ServerConnection(sourceServerName) { LoginSecure = true }
+				: new ServerConnection(sourceServerName, sourceUsername, sourcePassword);
 			var sourceServer = new Server(sourceConnection);
 			var sourceDatabase = sourceServer.Databases[sourceDatabaseName];
 
@@ -184,11 +187,17 @@ namespace AppHarbor.SqlServerBulkCopy
 			optionSet.WriteOptionDescriptions(Console.Out);
 		}
 
-		private static string GetConnectionString(string serverName, string databaseName, string username,
-			string password)
+		static string GetConnectionString(string serverName, string databaseName, string username, string password)
 		{
-			return string.Format("Server={0};Database={1};User ID={2};Password={3};",
-				serverName, databaseName, username, password);
+			var usingTrustedConnection =
+				string.IsNullOrEmpty(username) &&
+				string.IsNullOrEmpty(password);
+
+			var connectionStringFormat = usingTrustedConnection
+				? "Server={0};Database={1};Trusted_Connection=True;"
+				: "Server={0};Database={1};User ID={2};Password={3};";
+
+			return string.Format(connectionStringFormat, serverName, databaseName, username, password);
 		}
 	}
 }

--- a/src/AppHarbor.SqlServerBulkCopy/Program.cs
+++ b/src/AppHarbor.SqlServerBulkCopy/Program.cs
@@ -141,6 +141,8 @@ namespace AppHarbor.SqlServerBulkCopy
 
 					if (rows > 0)
 					{
+                        var columns = GetColumnNames(connection, table);
+
 						Console.Write(string.Format("Copying {0} - {1} rows, {2:0.00} MB: ", table, rows, dataSize/1024));
 						using (var command = connection.CreateCommand())
 						{
@@ -155,6 +157,10 @@ namespace AppHarbor.SqlServerBulkCopy
 									bulkCopy.DestinationTableName = string.Format("[{0}]", table);
 									bulkCopy.BatchSize = (int)rowBatchSize;
 									bulkCopy.BulkCopyTimeout = int.MaxValue;
+                                    foreach (var columnName in columns) {
+                                        bulkCopy.ColumnMappings.Add(columnName, columnName);
+                                    }
+
 									bulkCopy.WriteToServer(reader);
 								}
 							}
@@ -170,6 +176,28 @@ namespace AppHarbor.SqlServerBulkCopy
 			watch.Stop();
 			Console.WriteLine("Copy complete, total time {0} s", watch.ElapsedMilliseconds/1000);
 		}
+
+        private static List<string> GetColumnNames(SqlConnection connection, string tableName) {
+            var sql =
+                @"select column_name
+                from information_schema.columns 
+                where table_name = @tablename
+                and columnproperty(object_id(@tablename),column_name,'iscomputed') != 1";
+
+            using (var command = connection.CreateCommand()) {
+                command.CommandText = sql;
+                command.Parameters.Add(new SqlParameter("@tablename", tableName));
+
+                var cnames = new List<string>();
+                using (var reader = command.ExecuteReader()) {
+                    while (reader.Read()) {
+                        cnames.Add((string)reader[0]);
+                    }
+                }
+
+                return cnames;
+            }
+        }
 
 		private static void SqlRowsCopied(object sender, SqlRowsCopiedEventArgs e)
 		{

--- a/src/AppHarbor.SqlServerBulkCopy/Program.cs
+++ b/src/AppHarbor.SqlServerBulkCopy/Program.cs
@@ -57,11 +57,11 @@ namespace AppHarbor.SqlServerBulkCopy
 				{
 					throw new OptionException("destination server not specified", "dstserver");
 				}
-				if (destinationUsername == null)
+				if (destinationUsername == null && destinationPassword != null)
 				{
 					throw new OptionException("destination username not specified", "dstusername");
 				}
-				if (destinationPassword == null)
+				if (destinationPassword == null && destinationUsername != null)
 				{
 					throw new OptionException("destination password not specified", "dstpassword");
 				}


### PR DESCRIPTION
1. merged changes from jamestelfer's and tathamoddie's forks:
   - Added support for trusted connections
   - Explicitly set mapped columns, ignoring computed column
2. Added support for clearing the destination database prior to copying the data
