### PR TITLE
Bugfix for clearDestinationDatabase always true and new option --checkIdentityExists

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -5,3 +5,5 @@ This is a C# console app that copies data between Microsoft SQL Server databases
     AppHarbor.SqlServerBulkCopy.exe --srcserver=db000.appharbor.net --srcusername=dbxx --srcpassword=srcpassword --srcdatabasename=dbxx --dstserver=.\SQLEXPRESSADV --dstusername=dbyy --dstpassword=dstpassword --dstdatabasename=dbyy --ignoretables=TableToIgnore --cleardstdatabase
 
 For trusted connections, just skip both the username and password parameters.
+
+Use option --checkidentityexists if you are getting sql exceptions ([table] does not contain an identity column.) when trying to clear tables without identity columns.


### PR DESCRIPTION
- Bugfix for ClearDestinationDatabase. Option not set correctly and was always true.
- Added new option --checkidentityexists to avoid sql exception ([table] does not contain an identity column.) when reseeding on tables without identity column.
