### PR TITLE
fix for column names mapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,9 @@
 deploy
 deploy/*
 *.csproj.user
+*.DotSettings.user
 *.suo
 *.cache
 TestResults/
 lib/SqlServerManagementObjects/*.dll
+_Resharper.*


### PR DESCRIPTION
since the pull request #6 change (support for schema names other than dbo), the column mapping code was broken because it was looking for table name, eg: '[dbo].[FooBar]' in information_schema rather than looking for table name 'Foobar' and table schema 'dbo'

this change fixes that issue.
