### PR TITLE
Added support for tables that have computed columns or indexed views

### DIFF
--- a/src/AppHarbor.SqlServerBulkCopy/Program.cs
+++ b/src/AppHarbor.SqlServerBulkCopy/Program.cs
@@ -146,7 +146,8 @@ namespace AppHarbor.SqlServerBulkCopy
 							EXEC sp_msforeachtable ""ALTER TABLE ? NOCHECK CONSTRAINT all""
 
 							-- delete data in all tables
-							EXEC sp_msforeachtable ""DELETE FROM ?""
+							-- NOTE: The quoted identifier option is enabled to fix a bug where the query fails if DB has any computed columns or indexed views
+							EXEC sp_msforeachtable ""SET QUOTED_IDENTIFIER ON; DELETE FROM ?""
 
 							-- enable all constraints
 							exec sp_msforeachtable ""ALTER TABLE ? WITH CHECK CHECK CONSTRAINT all""


### PR DESCRIPTION
As noted in the [SQL Server documentation](http://technet.microsoft.com/en-us/library/ms174393.aspx) and in this [StackOverflow question](http://stackoverflow.com/questions/8388272/error-deleting-all-tables-delete-failed-because-the-following-set-options-have) tables that have computed columns or indexed views need the QUOTED_IDENTIFIER option to be toggled on before executing any CRUD operations (in this case the DELETE operation).

This pull request adds support for running the bulk copy on databases that have such tables.
